### PR TITLE
Fixing protobuff versions to avoid conflicts with wandb and onnx requ…

### DIFF
--- a/applications/popart/bert/requirements.txt
+++ b/applications/popart/bert/requirements.txt
@@ -7,6 +7,7 @@ nltk==3.6.5
 future==0.17.1
 onnx==1.11.0
 tqdm==4.45.0
+protobuf==3.19.4
 pytest==6.2.5
 pytest-forked==1.3.0
 pytest-pythonpath==0.7.3

--- a/applications/popart/deep_voice/requirements.txt
+++ b/applications/popart/deep_voice/requirements.txt
@@ -4,6 +4,7 @@ scipy==1.5.4
 torchaudio==0.8.0
 librosa==0.7.2
 nltk==3.6.5
+protobuf==3.19.4
 onnx==1.11.0
 tqdm==4.46.1
 six==1.15.0

--- a/applications/popart/faster-rcnn/requirements.txt
+++ b/applications/popart/faster-rcnn/requirements.txt
@@ -4,6 +4,7 @@ easydict
 tensorboardX
 wandb
 pycocotools
+protobuf==3.19.4
 onnx==1.11.0
 tqdm
 scipy==1.5.4

--- a/applications/popart/resnext_inference/requirements.txt
+++ b/applications/popart/resnext_inference/requirements.txt
@@ -1,4 +1,5 @@
 absl-py==0.11.0
+protobuf==3.19.4
 onnx==1.11.0
 Pillow==8.3.2
 torch==1.7.0

--- a/applications/popart/transformer_transducer/training/requirements.txt
+++ b/applications/popart/transformer_transducer/training/requirements.txt
@@ -8,6 +8,7 @@ pandas==1.1.5
 tqdm==4.46.1
 pyyaml==5.3
 onnx==1.11.0
+protobuf==3.19.4
 wandb==0.12.1
 numba>=0.52.0
 mpi4py>=3.0.3

--- a/applications/pytorch/bert/requirements.txt
+++ b/applications/pytorch/bert/requirements.txt
@@ -3,6 +3,7 @@ datasets>=1.17.0
 tokenizers>=0.10.3
 scipy>=1.5.4
 pyyaml>=5.4.1
+protobuf==3.19.4
 wandb==0.12.1
 pytest==6.2.5
 pytest-pythonpath>=0.7.3

--- a/applications/pytorch/cnns/requirements.txt
+++ b/applications/pytorch/cnns/requirements.txt
@@ -1,5 +1,6 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 cmake>=3.18
+protobuf==3.19.4
 pytest==6.2.5
 pytest-forked==1.3.0
 pytest-pythonpath==0.7.3

--- a/applications/pytorch/conformer/requirements.txt
+++ b/applications/pytorch/conformer/requirements.txt
@@ -2,6 +2,7 @@ numpy==1.19.5
 fire==0.4.0
 pyyaml==6.0
 pandas==1.1.5
+protobuf==3.19.4
 wandb==0.12.7
 pillow==8.4.0
 espnet==0.10.1

--- a/applications/pytorch/detection/requirements.txt
+++ b/applications/pytorch/detection/requirements.txt
@@ -7,5 +7,6 @@ pytest-pythonpath>=0.7.3
 requests>=2.26.0
 ruamel.yaml>=0.17.0
 torchvision==0.11.1+cpu
+protobuf==3.19.4
 yacs>=0.1.8
 scipy>=1.5.4

--- a/applications/pytorch/miniDALL-E/requirements.txt
+++ b/applications/pytorch/miniDALL-E/requirements.txt
@@ -7,6 +7,7 @@ ftfy
 regex
 omegaconf>=2.0.0
 taming-transformers-rom1504
+protobuf==3.19.4
 wandb==0.12.1
 pytest==6.2.5
 pytest-pythonpath>=0.7.3

--- a/applications/pytorch/vit/requirements.txt
+++ b/applications/pytorch/vit/requirements.txt
@@ -1,6 +1,7 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 transformers>=4.12.0
 pyyaml==5.4.1
+protobuf==3.19.4
 wandb==0.12.1
 pytest==6.2.4
 pytest-pythonpath==0.7.3


### PR DESCRIPTION
…irements

Currently, an upstream change in [protobuf](https://pypi.org/project/protobuf/) has resulted in dependency conflicts with the versions on wandb and onnx being used in certain applications:

Popart - BERT. FasterRCNN, ResNext, Transformer
Pytorch - BERT, all CNNs, Conformer, Detection, Fastpitch, Minidalle, Swin, Vit

This PR fixes the version of protobuf to be one that is compatible with both wandb and onnx, and other requirements of the above mentioned applications. 