### PR TITLE
Benchmarks/versioning fixes

### DIFF
--- a/nlp/bert/pytorch/benchmarks.yml
+++ b/nlp/bert/pytorch/benchmarks.yml
@@ -231,7 +231,7 @@ pytorch_bert_large_packed_sl384_pretrain_real_pod64_conv:
 
 # --- SQuAD ---
 squad_options: &squad_options
-      data:
+   data:
       throughput:
          regexp: "throughput=(.*) samples/s"
       loss:

--- a/speech/wenet_conformer/pytorch/requirements.txt
+++ b/speech/wenet_conformer/pytorch/requirements.txt
@@ -9,4 +9,4 @@ pytest==6.2.5
 editdistance==0.5.2
 horovod==0.24.0
 torchaudio==0.10.0+cpu
-git+https://github.com/graphcore/examples-utils@292047e7d29e25954cdfcf821320544dc11bfc04#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@e60289e0744c061dcfb060131cd3fbd7ad2840e0#egg=examples-utils


### PR DESCRIPTION
- Updating the WeNet conformer requirements file to have the latest and correct version of examples-utils
- Fixing the data field in pytorch BERT benchmarks yaml file