### PR TITLE
Conditionally updating examples_utils version for all apps

### DIFF
--- a/gnn/cluster_gcn/tensorflow2/requirements.txt
+++ b/gnn/cluster_gcn/tensorflow2/requirements.txt
@@ -15,4 +15,4 @@ scikit-learn==0.24.2
 tensorflow-addons==0.14.0
 trainlog==0.2
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/gnn/message_passing/tensorflow2/requirements.txt
+++ b/gnn/message_passing/tensorflow2/requirements.txt
@@ -8,4 +8,4 @@ pytest-pythonpath==0.7.4
 pytest-xdist==2.5.0
 regex==2022.4.24
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/gnn/tgn/tensorflow1/requirements.txt
+++ b/gnn/tgn/tensorflow1/requirements.txt
@@ -9,4 +9,4 @@ torch-scatter==2.0.6
 torch-sparse==0.6.9
 tqdm==4.60.0
 types-dataclasses==0.6.1
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/miscellaneous/sales_forecasting/tensorflow1/requirements.txt
+++ b/miscellaneous/sales_forecasting/tensorflow1/requirements.txt
@@ -1,3 +1,3 @@
 pytest==6.2.5
 pandas==1.1.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/multimodal/CLIP/pytorch/requirements.txt
+++ b/multimodal/CLIP/pytorch/requirements.txt
@@ -5,4 +5,4 @@ transformers==4.10.0
 ftfy==6.0.3
 torchvision==0.11.1
 pytest==6.2.5
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/multimodal/mini_dalle/pytorch/requirements.txt
+++ b/multimodal/mini_dalle/pytorch/requirements.txt
@@ -13,4 +13,4 @@ pytest==6.2.5
 pytest-pythonpath==0.7.4
 torchvision==0.11.1+cpu
 horovod==0.24.3
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/nlp/bert/popart/requirements.txt
+++ b/nlp/bert/popart/requirements.txt
@@ -16,6 +16,6 @@ pyyaml==5.4.1
 wandb==0.12.8
 filelock==3.0.12
 numba==0.53.1
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 mpi4py==3.1.3
 

--- a/nlp/bert/popxl/requirements.txt
+++ b/nlp/bert/popxl/requirements.txt
@@ -13,5 +13,5 @@ wandb==0.12.8
 
 pytest
 pytest-pythonpath
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 git+ssh://git@phabricator.sourcevertex.net/diffusion/POPXLADDONSINTERNAL/popxladdonsinternal.git@sdk-release-2.6#egg=popxl-addons

--- a/nlp/bert/pytorch/requirements.txt
+++ b/nlp/bert/pytorch/requirements.txt
@@ -11,4 +11,4 @@ tfrecord==1.14.1
 filelock==3.4.1
 mpi4py==3.1.3
 horovod==0.24.0 
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/nlp/bert/tensorflow1/requirements.txt
+++ b/nlp/bert/tensorflow1/requirements.txt
@@ -7,5 +7,5 @@ onnx==1.8.1
 pytest==6.2.5
 pytest-pythonpath==0.7.4
 scipy==1.5.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils
 

--- a/nlp/bert/tensorflow2/requirements.txt
+++ b/nlp/bert/tensorflow2/requirements.txt
@@ -10,5 +10,5 @@ tensorflow-addons==0.14.0
 tensorflow-datasets==4.4.0
 torch==1.9.0
 git+https://github.com/graphcore/transformers-fork@v4.18-gc#egg=transformers # Fork of transformers to support KerasTensor from the Keras package with Python 3.6.
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 wandb==0.12.8

--- a/nlp/gpt2/pytorch/requirements.txt
+++ b/nlp/gpt2/pytorch/requirements.txt
@@ -7,5 +7,5 @@ tfrecord>=1.13
 pytest==6.2.5
 pytest-pythonpath>=0.7.3
 horovod>=0.24.0 --no-binary=horovod
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 tqdm>=4.63.1

--- a/probability/contrastive_divergence_vae/tensorflow1/requirements.txt
+++ b/probability/contrastive_divergence_vae/tensorflow1/requirements.txt
@@ -20,7 +20,7 @@ statsmodels==0.12.1
 tensorflow-probability==0.7.0
 tqdm==4.64.0
 urllib3==1.26.6
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils
 
 # For machinable
 pendulum==2.1.2

--- a/probability/mcmc/tensorflow1/requirements.txt
+++ b/probability/mcmc/tensorflow1/requirements.txt
@@ -1,4 +1,4 @@
 tensorflow-probability==0.8
 pytest==6.2.5
 pytest-pythonpath==0.7.3
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/recommendation/autoencoder/tensorflow1/requirements.txt
+++ b/recommendation/autoencoder/tensorflow1/requirements.txt
@@ -1,3 +1,3 @@
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/recommendation/click_through_rate/tensorflow1/requirements.txt
+++ b/recommendation/click_through_rate/tensorflow1/requirements.txt
@@ -4,4 +4,4 @@ pytest==6.2.5
 pytest-forked==1.3.0
 pytest-pythonpath==0.7.4
 pytest-xdist==2.1.0
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/reinforcement_learning/rl_policy_model/tensorflow1/requirements.txt
+++ b/reinforcement_learning/rl_policy_model/tensorflow1/requirements.txt
@@ -1,3 +1,3 @@
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/sparsity/dynamic_sparsity/tensorflow1/requirements.txt
+++ b/sparsity/dynamic_sparsity/tensorflow1/requirements.txt
@@ -9,4 +9,4 @@ scipy==1.5.4
 jax==0.2.17
 jaxlib==0.1.69
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/speech/conformer/popart/requirements.txt
+++ b/speech/conformer/popart/requirements.txt
@@ -9,4 +9,4 @@ pytest==6.2.5
 pytest-pythonpath==0.7.4
 torch==1.10.0+cpu
 torchaudio==0.10.0+cpu
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/speech/deepvoice3/popart/requirements.txt
+++ b/speech/deepvoice3/popart/requirements.txt
@@ -10,4 +10,4 @@ tqdm==4.46.1
 six==1.15.0
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/speech/fastpitch/pytorch/requirements.txt
+++ b/speech/fastpitch/pytorch/requirements.txt
@@ -12,4 +12,4 @@ setuptools==59.5.0
 protobuf==3.19.4
 wandb==0.12.8
 git+https://github.com/NVIDIA/dllogger@v0.1.0#egg=dllogger
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/speech/fastspeech2/tensorflow2/requirements.txt
+++ b/speech/fastspeech2/tensorflow2/requirements.txt
@@ -11,5 +11,5 @@ scikit-learn==0.24.2
 pyworld==0.3.0
 wandb==0.12.8
 dataclasses==0.8; python_version < '3.7'
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 

--- a/speech/transformer_transducer/popart/training/requirements.txt
+++ b/speech/transformer_transducer/popart/training/requirements.txt
@@ -17,4 +17,4 @@ pytest==6.2.5
 torch==1.10.0+cpu
 --extra-index-url https://developer.download.nvidia.com/compute/redist 
 nvidia-dali-cuda110==0.28.0
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/cnns/pytorch/requirements.txt
+++ b/vision/cnns/pytorch/requirements.txt
@@ -13,4 +13,4 @@ checksumdir==1.2.0
 horovod==0.24.3
 tritonclient[grpc]==2.16.0
 git+https://github.com/lilohuang/PyTurboJPEG.git@8706665787c7290397859075ae2f0bf35afeb41a
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/cnns/tensorflow1/inference/requirements.txt
+++ b/vision/cnns/tensorflow1/inference/requirements.txt
@@ -8,4 +8,4 @@ pytest-forked==1.4.0
 scipy==1.5.4
 tensorflow-serving-api==1.15.0
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/vision/cnns/tensorflow1/training/requirements.txt
+++ b/vision/cnns/tensorflow1/training/requirements.txt
@@ -10,4 +10,4 @@ pytest-cov==3.0.0
 pytest-forked==1.4.0
 pytest-pythonpath==0.7.4
 pytest-xdist==2.5.0
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/vision/cnns/tensorflow2/requirements.txt
+++ b/vision/cnns/tensorflow2/requirements.txt
@@ -11,4 +11,4 @@ autopep8==1.6.0
 opencv-python==4.5.5.64
 mpi4py==3.1.3
 tensorflow-serving-api==2.6.3
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/dino/pytorch/requirements.txt
+++ b/vision/dino/pytorch/requirements.txt
@@ -5,4 +5,4 @@ torchvision==0.11.1+cpu
 pytest==6.2.4
 pyyaml==5.4.1
 horovod==0.24.0
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/efficientdet/tensorflow2/requirements.txt
+++ b/vision/efficientdet/tensorflow2/requirements.txt
@@ -7,4 +7,4 @@ six==1.16.0
 tensorflow-model-optimization==0.7.2
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/faster_rcnn/popart/requirements.txt
+++ b/vision/faster_rcnn/popart/requirements.txt
@@ -12,4 +12,4 @@ PyYAML==5.4.1
 torch==1.10.0+cpu
 torchvision==0.11.1+cpu
 fire==0.4.0
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/resnext_inference/popart/requirements.txt
+++ b/vision/resnext_inference/popart/requirements.txt
@@ -9,4 +9,4 @@ urllib3==1.26.6
 pretrainedmodels==0.7.4
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/swin/pytorch/requirements.txt
+++ b/vision/swin/pytorch/requirements.txt
@@ -7,4 +7,4 @@ wandb==0.12.8
 transformers==4.18.0
 yacs==0.1.8
 pyyaml==5.4.1
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/unet_medical/tensorflow2/requirements.txt
+++ b/vision/unet_medical/tensorflow2/requirements.txt
@@ -1,5 +1,5 @@
 pytest==6.2.5
 Pillow==8.4.0
 scikit-learn==0.24.2
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 

--- a/vision/vit/pytorch/requirements.txt
+++ b/vision/vit/pytorch/requirements.txt
@@ -10,4 +10,4 @@ pillow==8.4.0
 attrdict==2.0.1
 horovod==0.24.0
 randaugment==1.0.2
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils

--- a/vision/yolo_v3/tensorflow1/requirements.txt
+++ b/vision/yolo_v3/tensorflow1/requirements.txt
@@ -2,4 +2,4 @@ opencv-python==4.5.2.52
 easydict==1.9
 pytest==6.2.5
 tqdm==4.64.0
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@1a4ef42bfeb31ad1137db1c3c32fd21a6871bf72#egg=examples-utils

--- a/vision/yolo_v4/pytorch/requirements.txt
+++ b/vision/yolo_v4/pytorch/requirements.txt
@@ -12,5 +12,5 @@ torchvision==0.11.1+cpu
 protobuf==3.19.4
 wandb==0.12.8
 yacs==0.1.8
-git+https://github.com/graphcore/examples-utils@6d3b8367d5c6d2cda5a0e7849138d0ee8a8c6756#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
 torchinfo==1.5.4


### PR DESCRIPTION
Conditionally updates the examples_utils version for all apps.

For TF1/popart-deepvoice apps, the version is updated to head of the python_3.6_compatible branch in examples_utils (does not contain the commit which bumps the cppimport version)

For all other apps, the version i updated to the head of the master branch in examples utils