### PR TITLE
Popart bert data path fix

### DIFF
--- a/nlp/bert/popart/configs/packed/packed_pretrain_tiny_512.json
+++ b/nlp/bert/popart/configs/packed/packed_pretrain_tiny_512.json
@@ -47,6 +47,6 @@
     "lr_warmup_start" : 4e-3,
     "learning_rate": 8e-3,
     "weight_decay": 1e-2,
-    "input_files": ["data/jan2020_three_seq_per_pack_with_duplications_v2/*"],
+    "input_files": ["data/packed_sequence_128/duplication_*"],
     "engine_cache": "__cache_mlperf_bert_tiny"
 }


### PR DESCRIPTION
Fixes the input_files field in the packed/tiny 512 config to be consistent with all the other configs of this type.

Found by @evawGraphcore when investigating https://graphcore.zendesk.com/agent/tickets/4210