### PR TITLE
Fixing horovod setup in makefile

### DIFF
--- a/nlp/bert/pytorch/README.md
+++ b/nlp/bert/pytorch/README.md
@@ -340,23 +340,6 @@ In order to re-generate the sample dataset, run the following script:
 python3 third_party/create_pretraining_data.py --input-file data/sample_text.txt --output-file data/sample_text.tfrecord --sequence-length 128 --mask-tokens 20 --duplication-factor 4 --do-lower-case --model bert-base-uncased
 ```
 
-
-### Running and benchmarking
-
-To run a tested and optimised configuration and to reproduce the performance shown on our [performance results page](https://www.graphcore.ai/performance-results), please follow the setup instructions in this README to setup the environment, and then use the `examples_utils` module (installed automatically as part of the environment setup) to run one or more benchmarks. For example:
-
-```python
-python3 -m examples_utils benchmark --spec <path to benchmarks.yml file>
-```
-
-Or to run a specific benchmark in the `benchmarks.yml` file provided:
-
-```python
-python3 -m examples_utils benchmark --spec <path to benchmarks.yml file> --benchmark <name of benchmark>
-```
-
-For more information on using the examples-utils benchmarking module, please refer to [the README](https://github.com/graphcore/examples-utils/blob/master/examples_utils/benchmarks/README.md).
-
 ### Troubleshooting
 
 If Triton server tests fails with such error:

--- a/vision/cnns/pytorch/makefile
+++ b/vision/cnns/pytorch/makefile
@@ -3,9 +3,10 @@ all: install get-data install-turbojpeg
 install-turbojpeg: get-turbojpeg build-turbojpeg
 
 install:
-	pip install -r requirements.txt
-	pip uninstall pillow -y
-	CC="cc -mavx2" pip install --no-cache-dir -U --force-reinstall pillow-simd
+	pip3 install -r requirements.txt
+	pip3 uninstall pillow -y
+	CC="cc -mavx2" pip3 install --no-cache-dir -U --force-reinstall pillow-simd
+	HOROVOD_WITH_PYTORCH=1 pip3 install --no-cache-dir 'horovod==0.24.3'
 
 get-turbojpeg:
 	cd datasets && rm -rf libjpeg-turbo && git clone https://github.com/libjpeg-turbo/libjpeg-turbo.git
@@ -20,5 +21,5 @@ get-data:
 	cd datasets && ./get_images.sh
 
 test:
-	cd tests && pytest -n 10 --forked
-	cd tests_serial && pytest
+	cd tests && python3 -m pytest -n 10 --forked
+	cd tests_serial && python3 -m pytest

--- a/vision/cnns/pytorch/requirements.txt
+++ b/vision/cnns/pytorch/requirements.txt
@@ -13,7 +13,6 @@ timm==0.5.4
 wandb==0.12.8
 pyyaml==5.4.1
 checksumdir==1.2.0
-horovod==0.24.3
 tritonclient[grpc]==2.16.0
 git+https://github.com/lilohuang/PyTurboJPEG.git@8706665787c7290397859075ae2f0bf35afeb41a
 git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils


### PR DESCRIPTION
Adding the horovod installation in the PT CNNs makefile to fix the existing default installation method from the requirements file. This now solves issues with horovod not building correctly in some environments. 

Also adding the fix to the PT BERT readme where a section was duplicated by mistake. 