### PR TITLE
Patch release with GPTJ 16 IPUs config

### DIFF
--- a/nlp/gpt_j/popxl/README.md
+++ b/nlp/gpt_j/popxl/README.md
@@ -1,10 +1,9 @@
 # GPT-J
 GPT-J for NLP pre-training and text generation, optimised for Graphcore's IPU.
 
-| Framework | domain | Model | Datasets | Tasks| Training| Inference |
-|-------------|-|------|-------|-------|-------|---|
-| opXL | NLP | GPT-J | MNLI | Next sentence prediction, Question/Answering | ✅  | ✅ |
-
+| Framework | Domain | Model | Datasets | Tasks | Training | Inference |
+|-----------|--------|-------|----------|-------|----------|-----------|
+| popXL | NLP | GPT-J | MNLI | Next sentence prediction, Question/Answering | | <p style="text-align: center;">✅ <br> Min. 16 IPUs (POD16) required | <p style="text-align: center;">✅ <br> Min. 16 IPU (POD16) required |
 
 # Instructions summary
 
@@ -51,7 +50,6 @@ source <venv path>/bin/activate
 3. Install the Python requirements:
 ```bash
 pip3 install -r requirements.txt
-```nstall
 ```
 
 
@@ -72,9 +70,10 @@ The task is to predict the relation between the premise and the hypothesis, whic
 
 
 The default model size for fine-tuning is GPT-J 6B on POD64 (named `gptj_6B_1024_pod64`). You can
-change it to other configurations that are available in the configuration file `config/finetuning.yml` using the `- -config` CLI parameter:
+change it to other configurations that are available in the configuration file `config/finetuning.yml` using the `--config` CLI parameter.
+In particular, you can run fine-tuning on a POD16 using
 ```bash
-python3 run_finetuning_mnli.py - -config gptj_6B_1024_pod64
+python3 run_finetuning_mnli.py --config gptj_6B_1024_pod16
 ```
 
 When running the application, it is possible to save/load executables to/from a cache store. This allows for reusing a saved executable instead of re-compiling the model when re-running identical model configurations. To enable this, use the environment variable `POPXL_CACHE_DIR=<PATH/TO/CACHE>` when running the application:

--- a/nlp/gpt_j/popxl/config/finetuning_mnli.yml
+++ b/nlp/gpt_j/popxl/config/finetuning_mnli.yml
@@ -57,6 +57,17 @@ release:
       available_memory_proportion: [ 0.2 ]
       attention_serialisation: 2
 
+  "gptj_6B_1024_pod16":
+    <<: *gptj_6B_1024
+    execution:
+      micro_batch_size: 1
+      loss_scaling: 4096
+      io_tiles: 128
+      data_parallel: 1
+      tensor_parallel: 16
+      available_memory_proportion: [ 0.2 ]
+      attention_serialisation: 2
+
   tiny:
     <<: *tiny
     execution:

--- a/nlp/gpt_j/popxl/inference.py
+++ b/nlp/gpt_j/popxl/inference.py
@@ -70,10 +70,10 @@ def inference(config: GPTJConfig) -> TaskSession:
             # ----- Create Variables -----
 
             # Create RemoteBuffers for each variable
-            embeddings_buffers = named_variable_buffers(embeddings_facts)
+            embeddings_buffers = named_variable_buffers(embeddings_facts, shard_over_dict=False)
             layer_buffers = named_variable_buffers(
-                layer_facts, entries=config.model.layers)
-            lm_buffers = named_variable_buffers(lm_facts)
+                layer_facts, entries=config.model.layers, shard_over_dict=False)
+            lm_buffers = named_variable_buffers(lm_facts, shard_over_dict=False)
 
             variables = NamedTensors()
             transformer = NamedTensors()

--- a/nlp/gpt_j/popxl/requirements.txt
+++ b/nlp/gpt_j/popxl/requirements.txt
@@ -15,6 +15,6 @@ sklearn==0.0
 pytest==6.2.5
 pytest-pythonpath==0.7.4
 
-git+ssh://git@github.com/graphcore/popxl-addons.git@sdk-release-3.1
+git+ssh://git@github.com/graphcore/popxl-addons.git@sdk-release-3.1_a
 
 protobuf==3.20.*; python_version > '3.6'


### PR DESCRIPTION
Patch release branch with commits 868dcf5d1405a8a0783ec826ec829274b9038b43 and 3f64184f4efa6b87fae6b970a697a297841e582c from examples-internal, see also https://github.com/graphcore/examples-internal/pull/417

Changes:

- Add config for finetuning on POD16
- Requirements changed to [popxl-addons.git@sdk-release-3.1_a](mailto:popxl-addons-internal.git@sdk-release-3.1_a)
- Adapt named_variable_buffers to new addons API
- Readme update

Tested locally with sdk release
```
(3.1.0+1205_popart) sofial@neverland-poplar-31:~/workspace/dev/examples/nlp/gpt_j/popxl$ pytest
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /nethome/sofial/workspace/venvs/poplar_sdk-ubuntu_20_04-3.1.0+1205-58b501c780/3.1.0+1205_popart/bin/python3
cachedir: .pytest_cache
rootdir: /nethome/sofial/workspace/dev/examples/nlp/gpt_j/popxl, configfile: pytest.ini, testpaths: tests
plugins: pythonpath-0.7.4
collected 14 items                                                                                                                                                     

tests/integration/execution/test_execution.py::TestPretraining::test_finetuning_mnli PASSED                                                                      [  7%]
tests/integration/execution/test_execution.py::TestPretraining::test_inference PASSED                                                                            [ 14%]
tests/integration/layers/test_attention_TP.py::test_attention_TP_cmp_huggingface PASSED                                                                          [ 21%]
tests/integration/layers/test_attention_TP.py::test_attention_to_hf PASSED                                                                                       [ 28%]
tests/integration/layers/test_decoder_block_TP.py::test_decoder_block_TP_cmp_huggingface PASSED                                                                  [ 35%]
tests/integration/layers/test_decoder_block_TP.py::test_decoder_to_hf PASSED                                                                                     [ 42%]
tests/integration/layers/test_feed_forward_TP.py::test_feed_forward_TP_cmp_huggingface PASSED                                                                    [ 50%]
tests/integration/layers/test_feed_forward_TP.py::test_ff_to_hf PASSED                                                                                           [ 57%]
tests/integration/layers/test_gptj_TP.py::test_gptj_TP_cmp_huggingface PASSED                                                                                    [ 64%]
tests/integration/layers/test_gptj_TP.py::test_gptj_to_hf PASSED                                                                                                 [ 71%]
tests/integration/layers/test_lm_TP.py::test_lm_TP_cmp_huggingface PASSED                                                                                        [ 78%]
tests/integration/layers/test_lm_TP.py::test_lm_to_hf PASSED                                                                                                     [ 85%]
tests/unit/test_dataloder.py::test_epochs PASSED                                                                                                                 [ 92%]
tests/unit/test_dataloder.py::test_dataloader_checkpoints PASSED                                                                                                 [100%]
```