### PR TITLE
Change addons requirements to https, disable wandb by default

### DIFF
--- a/nlp/gpt_j/popxl/requirements.txt
+++ b/nlp/gpt_j/popxl/requirements.txt
@@ -15,6 +15,6 @@ sklearn==0.0
 pytest==6.2.5
 pytest-pythonpath==0.7.4
 
-git+ssh://git@github.com/graphcore/popxl-addons.git@sdk-release-3.1_a
+git+https://github.com/graphcore/popxl-addons.git@sdk-release-3.1_a
 
 protobuf==3.20.*; python_version > '3.6'

--- a/nlp/gpt_j/popxl/utils/setup.py
+++ b/nlp/gpt_j/popxl/utils/setup.py
@@ -124,7 +124,7 @@ def gptj_fine_tuning_setup(
 ) -> Tuple[GPTJConfig, argparse.Namespace, Optional[GPTJForCausalLM]]:
     """GPT-J setup for fine tunning scripts"""
     config, args, pretrained = gptj_config_setup(config_file, presets_key, default_config,
-                                                 wandb_setup=True, hf_model_setup=True)
+                                                 wandb_setup=False, hf_model_setup=True)
 
     return config, args, pretrained
 


### PR DESCRIPTION
Users typically don't have a wandb account.
In the README it is specified that you must login to wandb before running the script, but since 
running the script without logging cause errors it's better to have W&B only if explicitly specified. 