### PR TITLE
Updating the examples_util version to be latest stable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
       pass_filenames: false
       language: python
       additional_dependencies:
-        - 'git+https://github.com/graphcore/examples-utils.git@1aded5f35073d93fedcb516ad3782082daba3f87'
+        - 'git+https://github.com/graphcore/examples-utils.git@latest_stable'

--- a/gnn/cluster_gcn/tensorflow2/requirements.txt
+++ b/gnn/cluster_gcn/tensorflow2/requirements.txt
@@ -18,4 +18,4 @@ tensorflow-addons==0.14.0
 torch==1.13.0+cu116; python_version >= '3.9'
 trainlog==0.2
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/gnn/message_passing/tensorflow2/requirements.txt
+++ b/gnn/message_passing/tensorflow2/requirements.txt
@@ -11,4 +11,4 @@ regex==2022.4.24
 --find-links https://download.pytorch.org/whl/torch_stable.html
 torch==1.13.0+cu116; python_version >= '3.9'
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@8f57bfda96af84e3c931837bed052a657328d264#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/gnn/tgn/pytorch/requirements.txt
+++ b/gnn/tgn/pytorch/requirements.txt
@@ -5,4 +5,4 @@ torch-sparse==0.6.13
 tqdm==4.60.0
 pytest==6.2.5
 matplotlib
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/multimodal/CLIP/pytorch/requirements.txt
+++ b/multimodal/CLIP/pytorch/requirements.txt
@@ -8,4 +8,4 @@ torchvision==0.14.0+cpu; python_version > '3.6'
 torchvision==0.11.0+cpu; python_version <= '3.6'
 pytest==6.2.5
 protobuf==3.19.4
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/multimodal/frozen_in_time/pytorch/requirements.txt
+++ b/multimodal/frozen_in_time/pytorch/requirements.txt
@@ -60,4 +60,4 @@ zipp==3.6.0
 opencv-python-headless==4.6.0.66
 fire==0.4.0
 wandb==0.12.8
-git+https://github.com/graphcore/examples-utils@0863d5e6df28dacdf75d9c4aa212337f26d05c0d#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/multimodal/mini_dalle/pytorch/requirements.txt
+++ b/multimodal/mini_dalle/pytorch/requirements.txt
@@ -17,4 +17,4 @@ pytest-pythonpath==0.7.4
 torchvision==0.14.0+cpu; python_version > '3.6'
 torchvision==0.11.0+cpu; python_version <= '3.6'
 horovod==0.24.3
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/nlp/bert/popxl/requirements.txt
+++ b/nlp/bert/popxl/requirements.txt
@@ -15,7 +15,7 @@ wandb==0.12.8
 pytest
 pytest-pythonpath
 
-git+https://github.com/graphcore/examples-utils@e60289e0744c061dcfb060131cd3fbd7ad2840e0#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 git+ssh://git@github.com/graphcore/popxl-addons.git@sdk-release-3.1
 
 protobuf==3.20.*; python_version > '3.6'

--- a/nlp/bert/pytorch/requirements.txt
+++ b/nlp/bert/pytorch/requirements.txt
@@ -11,6 +11,6 @@ tfrecord==1.14.1
 filelock==3.4.1
 mpi4py==3.1.3
 horovod==0.24.0
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 cmake==3.22.4
 tritonclient[grpc]==2.16.0

--- a/nlp/bert/tensorflow2/requirements.txt
+++ b/nlp/bert/tensorflow2/requirements.txt
@@ -9,5 +9,5 @@ pytest-xdist==2.5.0
 tensorflow-addons==0.14.0
 tensorflow-datasets==4.4.0
 git+https://github.com/graphcore/transformers-fork@v4.18-gc#egg=transformers # Fork of transformers to support KerasTensor from the Keras package with Python 3.6.
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 wandb==0.12.8

--- a/nlp/gpt2/pytorch/requirements.txt
+++ b/nlp/gpt2/pytorch/requirements.txt
@@ -8,5 +8,5 @@ tfrecord>=1.13
 pytest==6.2.5
 pytest-pythonpath>=0.7.3
 horovod>=0.24.0
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 tqdm>=4.63.1

--- a/preview/vision/yolo_v4/pytorch/requirements.txt
+++ b/preview/vision/yolo_v4/pytorch/requirements.txt
@@ -12,5 +12,5 @@ torchvision==0.14.0+cpu
 protobuf==3.19.4
 wandb==0.12.1
 yacs==0.1.8
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 torchinfo==1.5.4

--- a/speech/conformer/pytorch/requirements.txt
+++ b/speech/conformer/pytorch/requirements.txt
@@ -11,4 +11,4 @@ editdistance==0.5.2
 horovod==0.24.0
 torchaudio==0.10.0+cpu; python_version<='3.6'
 torchaudio==0.13.0+cpu; python_version>'3.6'
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/speech/fastpitch/pytorch/requirements.txt
+++ b/speech/fastpitch/pytorch/requirements.txt
@@ -13,4 +13,4 @@ protobuf==3.19.4
 wandb==0.12.8
 horovod==0.24.3
 git+https://github.com/NVIDIA/dllogger@v0.1.0#egg=dllogger
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/speech/fastspeech2/tensorflow2/requirements.txt
+++ b/speech/fastspeech2/tensorflow2/requirements.txt
@@ -12,5 +12,5 @@ scikit-learn==0.24.2
 pyworld==0.3.0
 wandb==0.12.8
 dataclasses==0.8; python_version < '3.7'
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 

--- a/vision/cnns/pytorch/requirements.txt
+++ b/vision/cnns/pytorch/requirements.txt
@@ -15,4 +15,4 @@ pyyaml==5.4.1
 checksumdir==1.2.0
 tritonclient[grpc]==2.16.0
 git+https://github.com/lilohuang/PyTurboJPEG.git@8706665787c7290397859075ae2f0bf35afeb41a
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/cnns/tensorflow2/requirements.txt
+++ b/vision/cnns/tensorflow2/requirements.txt
@@ -12,4 +12,4 @@ opencv-python-headless==4.6.0.66
 mpi4py==3.1.3
 tensorflow-serving-api==2.6.3
 horovod[tensorflow]==0.26.1
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/dino/pytorch/requirements.txt
+++ b/vision/dino/pytorch/requirements.txt
@@ -10,4 +10,4 @@ pyyaml==5.4.1
 horovod==0.24.3
 wandb==0.12.8
 protobuf==3.19.4
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/efficientdet/tensorflow2/requirements.txt
+++ b/vision/efficientdet/tensorflow2/requirements.txt
@@ -7,4 +7,4 @@ six==1.15.0
 tensorflow-model-optimization==0.7.2
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/mae/pytorch/requirements.txt
+++ b/vision/mae/pytorch/requirements.txt
@@ -10,4 +10,4 @@ pyyaml>=5.4.1
 horovod>=0.24.0
 simplejpeg>=1.6.4
 wandb==0.12.1
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/swin/pytorch/requirements.txt
+++ b/vision/swin/pytorch/requirements.txt
@@ -14,4 +14,4 @@ horovod==0.24.3
 simplejpeg==1.6.4
 pytest==6.2.5
 pytest-pythonpath==0.7.4
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/unet_medical/tensorflow2/requirements.txt
+++ b/vision/unet_medical/tensorflow2/requirements.txt
@@ -1,5 +1,5 @@
 pytest==6.2.5
 Pillow==8.4.0
 scikit-learn==0.24.2
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 

--- a/vision/vit/pytorch/requirements.txt
+++ b/vision/vit/pytorch/requirements.txt
@@ -11,4 +11,4 @@ pillow==8.4.0
 attrdict==2.0.1
 horovod==0.24.0
 randaugment==1.0.2
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable

--- a/vision/yolo_v4/pytorch/requirements.txt
+++ b/vision/yolo_v4/pytorch/requirements.txt
@@ -13,5 +13,5 @@ torchvision==0.11.0+cpu; python_version <= '3.6'
 protobuf==3.19.4
 wandb==0.12.8
 yacs==0.1.8
-git+https://github.com/graphcore/examples-utils@0f3024827451878955ed495daf2e1b552eaf749f#egg=examples-utils
+git+https://github.com/graphcore/examples-utils@latest_stable
 torchinfo==1.5.4


### PR DESCRIPTION
Updating the version of examples utils used to fix a bug in when running benchmarks that specify wandb related arguments. 

This version will track the latest stable release of the examples_utils package, making futuer bug fixes easier to push.