### PR TITLE
Adding pod64 single host benchmark and tweaks

### DIFF
--- a/vision/cnns/pytorch/train/benchmarks.yml
+++ b/vision/cnns/pytorch/train/benchmarks.yml
@@ -16,7 +16,7 @@ common_options: &common_options
     - [loss, "loss"]
   env:
     POPLAR_ENGINE_OPTIONS: '{"opt.enableMultiAccessCopies":"false"}'
-    PYTORCH_CACHE_DIR: "./pt_cache/"
+    PYTORCH_CACHE_DIR: "./tmp/pt_cache/"
 
 config_options: &config_options
   requirements_path: requirements.txt
@@ -40,11 +40,40 @@ pytorch_resnet50_train_real_pod16:
       --dataloader-worker 14
       --dataloader-rebatch-size 256
 
-pytorch_resnet50_train_real_pod64_conv:
+pytorch_resnet50_train_real_1host_pod64_conv:
+  <<: [*common_options, *config_options]
+  description: |
+    ResNet training on 64 Mk2 IPUs with real data on a single host
+    for convergence testing.
+  cmd: >-
+    poprun
+      -vv
+      --num-instances=8
+      --num-replicas=64
+      --vipu-server-host=$IPUOF_VIPU_API_HOST
+      --vipu-server-port 8090
+      --vipu-partition=$IPUOF_VIPU_API_PARTITION_ID
+      --vipu-allocation=$VIPU_ALLOCATION_ID
+      --update-partition=yes
+      --remove-partition=yes
+      --reset-partition=no
+      --sync-type=ST_POD_NATIVE_DEFAULT
+      --executable-cache-path=$PYTORCH_CACHE_DIR
+    python3 train.py
+      --config resnet50-pod64
+      --dataloader-worker 28
+      --dataloader-rebatch-size 256
+      --imagenet-data-path $DATASETS_DIR/imagenet-raw-dataset
+      --checkpoint-output-dir ./checkpoints
+      --checkpoint-save-freq 100
+      --wandb
+      --validation-mode none
+
+pytorch_resnet50_train_real_4host_pod64_conv:
   <<: [*common_options, *config_options]
   description: |
     ResNet training on 64 Mk2 IPUs with real data
-    for convergence testing.
+    for convergence testing on 4 hosts.
   cmd: >-
     poprun
       -vv
@@ -77,6 +106,7 @@ pytorch_resnet50_train_real_pod64_conv:
       --dataloader-rebatch-size 256
       --imagenet-data-path $DATASETS_DIR/imagenet-raw-dataset
       --checkpoint-output-dir ./checkpoints
+      --checkpoint-save-freq 100
       --wandb
       --validation-mode none
 

--- a/vision/cnns/pytorch/train/train.py
+++ b/vision/cnns/pytorch/train/train.py
@@ -23,7 +23,6 @@ import models.loss
 import utils
 import datasets
 import datasets.augmentations as augmentations
-from datetime import datetime
 
 
 def train(training_model, training_data, args, lr_scheduler, epochs, optimizer, validation_function=None):
@@ -87,7 +86,7 @@ def train(training_model, training_data, args, lr_scheduler, epochs, optimizer, 
             update_lr(lr_scheduler, optimizer, training_model, state, args)
 
         # End of the epoch.
-        if not args.checkpoint_output_dir == "" and (state.epoch % args.checkpoint_save_freq) == 0:
+        if not args.checkpoint_output_dir == "":
             model_state = models.get_model_state_dict(training_model)
             optimizer_state = optimizer.state_dict()
             

--- a/vision/cnns/pytorch/train/train.py
+++ b/vision/cnns/pytorch/train/train.py
@@ -23,10 +23,12 @@ import models.loss
 import utils
 import datasets
 import datasets.augmentations as augmentations
+from datetime import datetime
 
 
 def train(training_model, training_data, args, lr_scheduler, epochs, optimizer, validation_function=None):
-    logging.info("Training the model")
+    training_start_time = datetime.now()
+    logging.info(f"Training the model. Start: {str(training_start_time)}")
 
     # A generic container used by the train function to set and update the host-side training state.
     class TrainingState(): pass
@@ -85,7 +87,7 @@ def train(training_model, training_data, args, lr_scheduler, epochs, optimizer, 
             update_lr(lr_scheduler, optimizer, training_model, state, args)
 
         # End of the epoch.
-        if not args.checkpoint_output_dir == "":
+        if not args.checkpoint_output_dir == "" and (state.epoch % args.checkpoint_save_freq) == 0:
             model_state = models.get_model_state_dict(training_model)
             optimizer_state = optimizer.state_dict()
             
@@ -113,6 +115,10 @@ def train(training_model, training_data, args, lr_scheduler, epochs, optimizer, 
                     running_mean_acc,
                     args,
                 )
+
+    training_end_time = datetime.now()
+    total_training_time = training_end_time - training_start_time
+    logging.info(f"Finished training. Time: {str(training_end_time)}. It took: {str(total_training_time)}")
 
 
 def get_augmented_samples(args, input_data, random_generator):

--- a/vision/cnns/pytorch/train/train_utils.py
+++ b/vision/cnns/pytorch/train/train_utils.py
@@ -37,7 +37,6 @@ def parse_arguments():
     parser.add_argument('--epoch', type=int, default=10, help="Number of training epochs")
     parser.add_argument('--checkpoint-input-dir', type=str, default="", help="The dir/path to load pre-existing checkpoints from to initialise a model. If not specified, no checkpoints will be used.")
     parser.add_argument('--checkpoint-output-dir', type=str, default="", help="The dir/path to save checkpoints to during training. If not specified, no checkpoints will be saved.")
-    parser.add_argument("--checkpoint-save-freq", type=int, default=1, help="Frequency of saving checkpoints when training.")
     parser.add_argument('--validation-mode', choices=['none', 'during', 'after'], default="after", help='The model validation mode. none=no validation; during=validate after every epoch; after=validate after the training')
     parser.add_argument('--wandb', action='store_true', help="Add Weights & Biases logging")
     parser.add_argument('--wandb-weight-histogram', action='store_true', help="Log the weight histogram with Weights & Biases")

--- a/vision/cnns/pytorch/train/train_utils.py
+++ b/vision/cnns/pytorch/train/train_utils.py
@@ -37,6 +37,7 @@ def parse_arguments():
     parser.add_argument('--epoch', type=int, default=10, help="Number of training epochs")
     parser.add_argument('--checkpoint-input-dir', type=str, default="", help="The dir/path to load pre-existing checkpoints from to initialise a model. If not specified, no checkpoints will be used.")
     parser.add_argument('--checkpoint-output-dir', type=str, default="", help="The dir/path to save checkpoints to during training. If not specified, no checkpoints will be saved.")
+    parser.add_argument("--checkpoint-save-freq", type=int, default=1, help="Frequency of saving checkpoints when training.")
     parser.add_argument('--validation-mode', choices=['none', 'during', 'after'], default="after", help='The model validation mode. none=no validation; during=validate after every epoch; after=validate after the training')
     parser.add_argument('--wandb', action='store_true', help="Add Weights & Biases logging")
     parser.add_argument('--wandb-weight-histogram', action='store_true', help="Log the weight histogram with Weights & Biases")


### PR DESCRIPTION
Moving a PR from examples-internal to examples. Originally authored by @kundaMwiza.

- Adds a singe-host POD64 benchmark to PT ResNet50 training
- Adds an argument to control the checkpointing frequency and sets that in the pod64 benchmarks
- Clearer training start/end logging