### PR TITLE
TF2: NIF example improvements

### DIFF
--- a/vision/neural_image_fields/tensorflow2/nif.py
+++ b/vision/neural_image_fields/tensorflow2/nif.py
@@ -207,10 +207,10 @@ def uv_positional_encode(uv, dimension, sigma, processes):
       for i in range(0, chunks):
         start = i * chunk_size
         end = start + chunk_size
-        if end > uv.shape[0]:
-          end = uv.shape[0]
-        uv_slice = uv[start:end, :]
-        result = p.apply_async(sincos, [coeffs, uv_slice, start])
+        if end > uv2.shape[0]:
+          end = uv2.shape[0]
+        uv2_slice = uv2[start:end, :]
+        result = p.apply_async(sincos, [coeffs, uv2_slice, start])
         async_results.append(result)
 
       for a in async_results:

--- a/vision/neural_image_fields/tensorflow2/predict_nif.py
+++ b/vision/neural_image_fields/tensorflow2/predict_nif.py
@@ -31,6 +31,13 @@ def parse_args():
         "metric will be computed between it and the reconstruction.",
     )
     parser.add_argument("--no-ipu", action="store_true", help="Set this flag to disable IPU specific code paths.")
+    parser.add_argument(
+        "--encoder-processes",
+        type=int,
+        default=40,
+        help="Number of processes used to encode input coordinates during dataset generation. "
+        "This should be chosen so that each process encodes thousands of samples.",
+    )
     args = parser.parse_args()
     return args
 
@@ -84,7 +91,7 @@ if __name__ == "__main__":
         prediction_batches = output_sample_count // prediction_batch_size
         print(f"Required samples: {output_sample_count} and batches: {prediction_batches}")
         eval_ds, pixel_coords = nif.make_prediction_dataset(
-            width, height, prediction_batch_size, embedding_dimension, embedding_sigma
+            width, height, prediction_batch_size, embedding_dimension, embedding_sigma, args.encoder_processes
         )
         result = model.predict(x=eval_ds, batch_size=prediction_batch_size, steps=prediction_batches)
         reconstructed = nif.decode_samples(

--- a/vision/neural_image_fields/tensorflow2/train_nif.py
+++ b/vision/neural_image_fields/tensorflow2/train_nif.py
@@ -216,7 +216,7 @@ if __name__ == "__main__":
     print(
         f"Image loaded. Size: {img.shape} Type: {img.dtype} Mean value: {input_mean} Min/max: {input_min}/{input_max}"
     )
-    rng = np.random.default_rng()
+    rng = np.random.default_rng(1)
 
     if args.deterministic_samples:
         # Create one uv sample per pixel.
@@ -343,13 +343,14 @@ if __name__ == "__main__":
             steps_per_exec = 1
         else:
             callbacks = [
-                # Two save callbacks: one is for standard Keras format:
-                tf.keras.callbacks.ModelCheckpoint(
-                    filepath=saved_model_path, save_weights_only=False, save_best_only=False
-                ),
-                # Second callback is for export to a format the Poplar ray-tracer can read:
+                # Two save callbacks:
+                # Save in a format the Poplar ray-tracer can read:
                 tf.keras.callbacks.ModelCheckpoint(
                     filepath=h5_model_path, include_optimizer=False, save_weights_only=False, save_best_only=False
+                ),
+                # Save in standard Keras format:
+                tf.keras.callbacks.ModelCheckpoint(
+                    filepath=saved_model_path, save_weights_only=False, save_best_only=False
                 ),
                 eval_callback,
                 tf.keras.callbacks.TensorBoard(log_dir=tb_logdir, histogram_freq=5),

--- a/vision/neural_image_fields/tensorflow2/train_nif.py
+++ b/vision/neural_image_fields/tensorflow2/train_nif.py
@@ -162,6 +162,13 @@ def parse_args():
         default=10,
         help="Interval in epochs at which to log training stats and evaluate PSNR (if enabled).",
     )
+    parser.add_argument(
+        "--encoder-processes",
+        type=int,
+        default=40,
+        help="Number of processes used to encode input coordinates during dataset generation. "
+        "This should be chosen so that each process encodes thousands of samples.",
+    )
     parser.add_argument("--siren", action="store_true", help="Use a SIREN MLP instead of an relu-MLP network.")
     parser.add_argument("--sin-fp16", action="store_true", help="If using SIREN use half precision sin function.")
     parser.add_argument(
@@ -261,7 +268,7 @@ if __name__ == "__main__":
     embedding_dimension = 0 if args.no_position_embedding else args.embedding_dimension
     if not args.no_position_embedding:
         t0 = time.time()
-        train_uv = nif.uv_positional_encode(train_uv, embedding_dimension, args.embedding_sigma)
+        train_uv = nif.uv_positional_encode(train_uv, embedding_dimension, args.embedding_sigma, args.encoder_processes)
         t1 = time.time()
         print(f"UV encode time: {t1 - t0}")
 

--- a/vision/neural_image_fields/tensorflow2/train_nif.py
+++ b/vision/neural_image_fields/tensorflow2/train_nif.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     print(
         f"Image loaded. Size: {img.shape} Type: {img.dtype} Mean value: {input_mean} Min/max: {input_min}/{input_max}"
     )
-    rng = np.random.default_rng(1)
+    rng = np.random.default_rng()
 
     if args.deterministic_samples:
         # Create one uv sample per pixel.


### PR DESCRIPTION
This change contains two improvements:

1. Works around a file system race condition with the HP5 file save and load in Keras callbacks.
2. Uses MultiProcess.Pool to parallelise uv sample encoding (~2x speed-up for large numbers of samples).

The race condition was rare but occurs frequently on Paperspace notebooks (seemingly due to the performance of Docker overlay file-systems).