### PR TITLE
Add links to run notebooks on Paperspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Graphcore Application examples
+# Graphcore Application Examples
 
 This repository contains a catalogue of application examples that have been optimised to run on Graphcore IPUs for both training and inference. Access reproducible code for a wide range of popular models covering NLP, Computer Vision, Speech, Multimodal, GNNs, AI for Simulation, Recommender Systems, and more. This includes a selection of models that achieve state of the art performance on IPUs, as well as code examples for self-learning.
 
@@ -6,28 +6,28 @@ Run models out-the-box on IPUs integrated with popular ML frameworks and librari
 
 ![Snip 2022-07-05 20 04 06](https://user-images.githubusercontent.com/81682248/177397772-4b671628-a7f4-4d8f-849d-2c5b54dba1de.png)
 
-To see what's new and easily filter applications by domain and framework, please check out our [Model Garden](https://www.graphcore.ai/resources/model-garden) :tulip:.
+To see what's new, check out our [Model Garden](https://www.graphcore.ai/resources/model-garden) :tulip:, where you can easily filter applications by domain and framework.
 
-For more detailed benchmark information, please visit our [Performance Results page](https://www.graphcore.ai/performance-results).
+For more detailed benchmark information, visit our [Performance Results page](https://www.graphcore.ai/performance-results).
 
-> The code presented here requires using Poplar SDK 3.2.x, and has been tested using Ubuntu 20.04 and Python 3.8
+> The code presented here requires you to use Poplar SDK 3.2.x, and has been tested using Ubuntu 20.04 and Python 3.8
 
 Please install and enable the Poplar SDK following the instructions in the [Getting Started](https://docs.graphcore.ai/en/latest/getting-started.html#pod-system-getting-started-guides) guide for your IPU system.
 
-## Developer Resources
+## Developer resources
 - [Documentation](https://docs.graphcore.ai/en/latest/): Explore our software documentation, user guides, and technical notes
-- [Tutorials](https://github.com/graphcore/tutorials/tree/master/tutorials): Hands-on code tutorials, simple application and feature examples
+- [Tutorials](https://github.com/graphcore/examples/tree/master/tutorials/tutorials): Hands-on code tutorials, simple application and feature examples
 - [How-to Videos](https://www.graphcore.ai/resources/how-to-videos): Watch practical how-to videos and demos by Graphcore engineers
 - [Research Papers](https://www.graphcore.ai/resources/research-papers): Read publications from Graphcore's Research team and IPU innovators
 
 ## Support
 
-If you encounter a problem or want to suggest an improvement to our example application please raise a Github issue, contact us at
-[support@graphcore.ai](mailto:support@graphcore.ai?subject=Applications%20Feedback), or get in touch through the #help channel of our slack community!
+If you encounter a problem or want to suggest an improvement to our example applications please raise a GitHub issue, contact us at
+[support@graphcore.ai](mailto:support@graphcore.ai?subject=Applications%20Feedback), or get in touch through the #help channel of the Graphcore Slack Community!
 
 [![Join our Slack Community](https://img.shields.io/badge/Slack-Join%20Graphcore's%20Community-blue?style=flat-square&logo=slack)](https://www.graphcore.ai/join-community)
 
-If you require POD128/256 setup and configuration for our applications, please contact [our engineering support](https://www.graphcore.ai/support).
+If you require POD128 or POD256 setup and configuration for our applications, please contact [our engineering support](https://www.graphcore.ai/support).
 <br>
 
 
@@ -50,109 +50,115 @@ If you require POD128/256 setup and configuration for our applications, please c
 
 ### <img width="30" src="https://user-images.githubusercontent.com/81682248/177352641-89d12db1-45df-4403-8308-c6b9015a027d.png"></a> Computer Vision <a name="cv"></a>
 
-| Model | Domain | Type |Links |
-| ------- | ------- |------- | ------- |
-| ResNet  | Image Classification | Training & Inference | [TensorFlow 2](vision/cnns/tensorflow2/), [PyTorch](vision/cnns/pytorch/), [PyTorch Lightning](https://github.com/graphcore/pytorch-lightning-examples/tree/release/applications)|
-| EfficientNet | Image Classification | Training & Inference | [PyTorch](vision/cnns/pytorch/), [PyTorch Lightning](https://github.com/graphcore/pytorch-lightning-examples/tree/release/applications)|
-| MobileNetv3 | Image Classification | Training & Inference | [PyTorch](vision/cnns/pytorch/) |
-| ViT(Vision Transformer) | Image Classification | Training | [PyTorch](vision/vit/pytorch/), [Hugging Face Optimum](https://huggingface.co/Graphcore/vit-base-ipu) |
-| DINO | Image Classification | Training | [PyTorch](vision/dino/pytorch) |
-| Swin | Image Classification | Training | [PyTorch](vision/swin/pytorch)  |
-| MAE (Masked AutoEncoder) | Image Classification | Training | [PyTorch](vision/mae/pytorch)  |
-| Yolov4-P5 | Object Detection | Inference | [PyTorch](vision/yolo_v4/pytorch) |
-| EfficientDet | Object Detection | Inference | [TensorFlow 2](vision/efficientdet/tensorflow2) |
-| UNet (Medical) | Image segmentation | Training & Inference | [TensorFlow 2](vision/unet_medical/tensorflow2)  |
-| Neural Image Fields | Neural Radiance Fields | Training | [TensorFlow 2](vision/neural_image_fields/tensorflow2)  |
+| Model | Domain | Type | Source | Run on Gradient |
+| ------- | ------- | ------- | ------- | ------- |
+| ResNet | Image classification | Training, Inference | [TensorFlow 2](vision/cnns/tensorflow2/), [PyTorch](vision/cnns/pytorch/), [PyTorch Lightning](https://github.com/graphcore/pytorch-lightning-examples/tree/release/applications) | - |
+| EfficientNet | Image classification | Training, Inference | [PyTorch](vision/cnns/pytorch/), [PyTorch Lightning](https://github.com/graphcore/pytorch-lightning-examples/tree/release/applications) | - |
+| MobileNetv3 | Image classification | Training, Inference | [PyTorch](vision/cnns/pytorch/) | - |
+| ViT (Vision Transformer) | Image classification | Training | [PyTorch](vision/vit/pytorch/), [Hugging Face Optimum](https://huggingface.co/Graphcore/vit-base-ipu) | [PyTorch](https://ipu.dev/3W2Ru39), [Hugging Face Optimum](https://ipu.dev/3YOs4Js) |
+| DINO | Image classification | Training | [PyTorch](vision/dino/pytorch) | - |
+| Swin | Image classification | Training | [PyTorch](vision/swin/pytorch) | - |
+| MAE (Masked AutoEncoder) | Image classification | Training | [PyTorch](vision/mae/pytorch) | - |
+| Yolov4-P5 | Object detection | Inference | [PyTorch](vision/yolo_v4/pytorch) | [PyTorch](https://ipu.dev/Y8yaSU) |
+| EfficientDet | Object detection | Inference | [TensorFlow 2](vision/efficientdet/tensorflow2) | - |
+| UNet (Medical) | Image segmentation | Training, Inference | [TensorFlow 2](vision/unet_medical/tensorflow2) | - |
+| Neural Image Fields | Neural radiance fields | Training | [TensorFlow 2](vision/neural_image_fields/tensorflow2) | - |
 <br>
 
 ### <img width="30" src="https://user-images.githubusercontent.com/81682248/177355208-a49a2bba-dd4d-4467-b135-9023279e8f01.png"></a> Natural Language Processing <a name="nlp"></a>
 
-| Model | Domain | Type |Links |
-| ------- | ------- |------- | ------- |
-| BERT | NLP | Training & Inference | [PyTorch](nlp/bert/pytorch) , [TensorFlow 2](nlp/bert/tensorflow2/), [PopXL](nlp/bert/popxl), [PaddlePaddle](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/model_zoo/bert/static_ipu), [Hugging Face Optimum](https://huggingface.co/Graphcore/bert-large-ipu)|
-| Packed BERT | NLP | Training |[PyTorch](nlp/bert/pytorch) |
-| GPT2 | NLP | Training |[PyTorch](nlp/gpt2/pytorch) , [Hugging Face Optimum](https://huggingface.co/Graphcore/gpt2-medium-ipu) |
-| GPTJ | NLP | Training |[PopXL](nlp/gpt_j/popxl)|
-| GPT3-2.7B | NLP | Training |[PopXL](nlp/gpt3_2.7B/popxl) |
-| GPT3-175B | NLP | Training |[PopXL](nlp/gpt3_175B/popxl) |
-| RoBERTa | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/roberta-large-ipu)|
-| DeBERTa | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/deberta-base-ipu)|
-| HuBERT | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/hubert-base-ipu)|
-| BART | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/bart-base-ipu)|
-| T5 | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/t5-small-ipu)|
-| Bloom | NLP | Inference |[PopXL](nlp/bloom/popxl) |
+| Model | Domain | Type | Source | Run on Gradient |
+| ------- | ------- | ------- | ------- | ------- |
+| BERT | NLP | Training, Inference | [PyTorch](nlp/bert/pytorch) , [TensorFlow 2](nlp/bert/tensorflow2/), [PopXL](nlp/bert/popxl), [PaddlePaddle](https://github.com/PaddlePaddle/PaddleNLP/tree/develop/model_zoo/bert/static_ipu), [Hugging Face Optimum](https://huggingface.co/Graphcore/bert-large-ipu) | - |
+| Packed BERT | NLP | Training | [PyTorch](nlp/bert/pytorch) | - |
+| BERT-large | NLP | Fine-tuning | [Hugging Face Optimum](https://huggingface.co/Graphcore/bert-large-ipu) | [Hugging Face Optimum](https://ipu.dev/3W9wwAD)|
+| GPT2 | NLP | Training | [PyTorch](nlp/gpt2/pytorch), [Hugging Face Optimum](https://huggingface.co/Graphcore/gpt2-medium-ipu) | - |
+| GPTJ | NLP | Training | [PopXL](nlp/gpt_j/popxl) | - |
+| GPT3-2.7B | NLP | Training | [PopXL](nlp/gpt3_2.7B/popxl) | - |
+| GPT3-175B | NLP | Training | [PopXL](nlp/gpt3_175B/popxl) | - |
+| RoBERTa | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/roberta-large-ipu) | - |
+| DeBERTa | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/deberta-base-ipu) | - |
+| HuBERT | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/hubert-base-ipu) | - |
+| BART Base | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/bart-base-ipu) | [Hugging Face Optimum](https://ipu.dev/3XbkoQk) |
+| T5-small | NLP | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/t5-small-ipu) | [Hugging Face Optimum](https://ipu.dev/3Ky3VCj) |
+| Bloom | NLP | Inference | [PopXL](nlp/bloom/popxl) | - |
+| Dolly | NLP | Inference | [PopXL](nlp/dolly/popxl) | [PopXL](https://ipu.dev/t8Jxz1) |
+| MT5-small | NLP | Fine-tuning | [Hugging Face Optimum](https://huggingface.co/Graphcore/mt5-small-ipu) | [Hugging Face Optimum](https://ipu.dev/d6vE2P) |
+| MT5-large | NLP | Fine-tuning | [Hugging Face Optimum](https://huggingface.co/Graphcore/mt5-large-ipu) | [Hugging Face Optimum](https://ipu.dev/6vL5xc) |
 
 <br>
 
 
 ### <img width="30" src="https://user-images.githubusercontent.com/81682248/177355502-87b09860-d323-438a-a0a2-247b8f6e9349.png"></a> Speech <a name="speech"></a>
 
-| Model | Domain | Type |Links |
-| ------- | ------- |------- | ------- |
-| Fastpitch | TTS (TextToSpeech) | Training | [PyTorch](speech/fastpitch/pytorch) |
-| Conformer | STT(SpeechToText) | Training & Inference | [PyTorch](speech/conformer/pytorch)|
-| Wav2Vec2 | STT(SpeechToText) | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/wav2vec2-base-ipu)|
+| Model | Domain | Type | Source | Run on Gradient |
+| ------- | ------- | ------- | ------- | ------- |
+| Fastpitch | TTS (TextToSpeech) | Training | [PyTorch](speech/fastpitch/pytorch) | - |
+| Conformer | STT (SpeechToText) | Training, Inference | [PyTorch](speech/conformer/pytorch) | - |
+| wav2vec2-base | STT (SpeechToText) | Fine-tuning, Inference | [Hugging Face Optimum](https://huggingface.co/Graphcore/wav2vec2-base-ipu) | [Hugging Face Optimum (Fine-tuning)](https://ipu.dev/3WsskMd), [Hugging Face Optimum (Inference)](https://ipu.dev/3W4juV4)|
+| wav2vec2-large | STT (SpeechToText) | Fine-tuning, Inference | [Hugging Face Optimum](https://huggingface.co/Graphcore/wav2vec2-large-ipu) | - |
+| Whisper-tiny | STT (SpeechToText) | Inference | [Hugging Face Optimum](https://huggingface.co/Graphcore/whisper-tiny-ipu) | [Hugging Face Optimum](https://ipu.dev/0LTbKM) |
 
 <br>
 
 ### <img width="30" src="https://user-images.githubusercontent.com/81682248/177357173-57e4cc6f-cff3-43a9-bd40-dcf3616f1fa1.png"></a> Multimodal <a name="multimodal"></a>
 
-| Model | Domain | Type |Links |
-| ------- | ------- |------- | ------- |
-| miniDALL-E | multimodal | Training | [PyTorch](multimodal/mini_dalle/pytorch) |
-| CLIP | multimodal | Training |[PyTorch](multimodal/CLIP/pytorch)|
-| LXMERT | multimodal | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/lxmert-base-ipu)|
-| Frozen in time | multimodal | Training & Inference |[PyTorch](multimodal/frozen_in_time/pytorch)|
+| Model | Domain | Type | Source | Run on Gradient |
+| ------- | ------- | ------- | ------- | ------- |
+| miniDALL-E | Multimodal | Training | [PyTorch](multimodal/mini_dalle/pytorch) | - |
+| CLIP | Multimodal | Training | [PyTorch](multimodal/CLIP/pytorch) | - |
+| LXMERT | Multimodal | Training | [Hugging Face Optimum](https://huggingface.co/Graphcore/lxmert-base-ipu) | - |
+| Frozen in time | Multimodal | Training, Inference | [PyTorch](multimodal/frozen_in_time/pytorch) | - |
 
 <br>
 
 ### <img width="25" src="https://user-images.githubusercontent.com/81682248/177357459-84ed7863-6477-4d8f-b63e-3db6c2ad405c.png"></a> Graph Neural Network <a name="gnn"></a>
 
-| Model | Domain | Type |Links |
-| ------- | ------- |------- | ------- |
-| MPNN (Message Passing Neural Networks) | GNN | Training & Inference | [PyTorch Geometric](gnn/message_passing/pytorch_geometric) , [TensorFlow 2](gnn/message_passing/tensorflow2) |
-| Spektral GNN library with QM9 | GNN | Training | [TensorFlow 2](gnn/spektral/tensorflow2)  |
-| Cluster GCN | GNN | Training & Inference | [PyTorch Geometric](gnn/cluster_gcn/pytorch_geometric) , [TensorFlow 2](gnn/cluster_gcn/tensorflow2) |
-| TGN (Temporal Graph Networks) | GNN | Training | [PyTorch](gnn/tgn/pytorch) |
-| NBFNet | GNN | Training & Inference | [PyTorch Geometric](gnn/nbfnet/pytorch_geometric) |
-| SchNet | GNN | Training & Inference | [PyTorch Geometric](gnn/schnet/pytorch_geometric) |
-| GPS++ - OGB-LSC PCQM4Mv2 competition submission | GNN | Training & Inference | [TensorFlow 2](gnn/ogb_lsc_pcqm4mv2/tensorflow2) |
+| Model | Domain | Type | Source | Run on Gradient |
+| ------- | ------- | ------- | ------- | ------- |
+| MPNN (Message Passing Neural Networks) | GNN | Training, Inference | [PyTorch Geometric](gnn/message_passing/pytorch_geometric) , [TensorFlow 2](gnn/message_passing/tensorflow2) | - |
+| Spektral GNN library with QM9 | GNN | Training | [TensorFlow 2](gnn/spektral/tensorflow2) | - |
+| Cluster GCN | GNN | Training, Inference | [PyTorch Geometric](gnn/cluster_gcn/pytorch_geometric) , [TensorFlow 2](gnn/cluster_gcn/tensorflow2) | [PyTorch Geometric](https://ipu.dev/PmAtSw), [TensorFlow 2](https://ipu.dev/3CHtqfy) |
+| TGN (Temporal Graph Networks) | GNN | Training | [PyTorch](gnn/tgn/pytorch) | - |
+| NBFNet | GNN | Training, Inference | [PyTorch Geometric](gnn/nbfnet/pytorch_geometric) | [PyTorch Geometric (Training)](https://ipu.dev/EzpMQD)|
+| SchNet | GNN | Training, Inference | [PyTorch Geometric](gnn/schnet/pytorch_geometric) | [PyTorch Geometric](https://ipu.dev/zUl8uW) |
+| GPS++ - OGB-LSC PCQM4Mv2 competition submission | GNN | Training, Inference | [TensorFlow 2](gnn/ogb_lsc_pcqm4mv2/tensorflow2) | [TensorFlow 2 (Training)](https://ipu.dev/3GxXZpe), [TensorFlow 2 (Inference)](https://ipu.dev/3CGjC5E)|
 
 <br>
 
 ### <img width="25" src="https://user-images.githubusercontent.com/81682248/177359725-f8b1c268-ddbb-41c5-a037-16168564cacc.png"></a> AI for Simulation <a name="simulation"></a>
 
-| Model | Domain | Type |Links |
-| ------- | ------- |------- | ------- |
-| Approximate Bayesian Computation (ABC) COVID-19 | Medical | Inference | [TensorFlow 2](ai_for_simulation/abc_covid_19/tensorflow2)  |
+| Model | Domain | Type | Source | Run on Gradient |
+| ------- | ------- | ------- | ------- | ------- |
+| Approximate Bayesian Computation (ABC) COVID-19 | Medical | Inference | [TensorFlow 2](ai_for_simulation/abc_covid_19/tensorflow2) | - |
 
 
 <br>
 
 
 ## Benchmarking tools
-To easily run the examples with tested and optimised configurations and to reproduce the performance shown on our [performance results page](https://www.graphcore.ai/performance-results), you can use the examples-utils benchmarking module, which comes with every example when you install its requirements. To use this simple, shared interface for almost any of the examples provided here, locate and look through the example's `benchmarks.yml` file and run:
+To easily run the examples with tested and optimised configurations and to reproduce the performance shown on our [Performance Results page](https://www.graphcore.ai/performance-results), you can use the `examples-utils` benchmarking module, which comes with every example when you install its requirements. To use this simple, shared interface for almost any of the examples provided here, locate and look through the example's `benchmarks.yml` file and run:
 
 ```bash
 python3 -m examples_utils benchmark --spec <path to benchmarks.yml file> --benchmark <name of benchmark>
 ```
 
-For more information on using the examples-utils benchmarking module, please refer to [the README](https://github.com/graphcore/examples-utils/blob/master/examples_utils/benchmarks/README.md).
+Refer to the [`examples-utils` benchmarking module README](https://github.com/graphcore/examples-utils/blob/master/examples_utils/benchmarks/README.md) for more information.
 
 <br>
 
 ## PopVision® Tools
-Visualise your code's inner workings with a user-friendly, graphical interface to optimise your machine learning models.
+Visualise your code's inner workings with PopVision, a user-friendly, graphical interface to optimise your machine learning models.
 
-[Download](https://www.graphcore.ai/developer/popvision-tools) PopVision to analyse IPU performance and utilisation.
+[Download the PopVision tools](https://www.graphcore.ai/developer/popvision-tools) to analyse IPU performance and utilisation.
 
 <br>
 
 ## Utilities
-The [utils/](utils) folder contains utilities libraries and scripts that are used across the other code examples. This includes:
+The [`utils/`](utils) folder contains utility libraries and scripts that are used across the code examples. This includes:
 
-* [utils/examples_tests](utils/examples_tests) - Common Python helper functions for the repository's unit tests
-* [utils/benchmarks](utils/benchmarks) - Common Python helper functions for running benchmarks on the IPU in different frameworks
+* [`utils/examples_tests`](utils/examples_tests) - Common Python helper functions for the `examples` repository unit tests
+* [`utils/benchmarks`](utils/benchmarks) - Common Python helper functions for running benchmarks on the IPU in different frameworks
 
 <br>
 
@@ -167,7 +173,7 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
 <summary>March 2023</summary>
 <br>
 
-*  Added this model below to reference models
+*  Added the following models:
     *  GNN: NBFNet (PyTorch Geometric), SchNet (PyTorch Geometric), Cluster-GCN (PyTorch Geometric), GIN (PyTorch Geometric), GPS++ - OGB-LSC PCQM4Mv2 competition submission (TensorFlow 2)
     *  NLP : GPT3_175B (PopXL), Bloom (PopXL)
 *  Removed all PopART applications, as well as the following:
@@ -176,14 +182,14 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
     * (Preview) Multimodel: ruDalle
     * Speech: FastSpeech2
     * Vision: ResNeXt inference
-* Moved the contents of the [Graphcore/tutorials](https://github.com/graphcore/tutorials) repository into this repository (PopART tutorials have also been removed)
+* Moved the contents of the [`Graphcore/tutorials`](https://github.com/graphcore/tutorials) repository into this repository (PopART tutorials have also been removed)
 </details>
 
 <details>
 <summary>Dec 2022</summary>
 <br>
 
-*  Added this model below to reference models
+*  Added the following models:
     *  GNN: TGN (PyTorch)
 *  Deprecating all PopART applications. Support will be removed in the next release.
 *  Removed all TensorFlow 1 applications.
@@ -194,10 +200,10 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
 <summary>Sep 2022</summary>
 <br>
 
-*  Added those models below to reference models
+*  Added the following models:
     *  Vision : MAE (PyTorch), G16 EfficientNet (PyTorch)
     *  NLP : GPTJ (PopXL), GPT3-2.7B (PopXL)
-    *  Multimodal : Frozen in time (PyTorchs), ruDalle(Preview) (PopXL)
+    *  Multimodal : Frozen in time (PyTorch), ruDalle (Preview) (PopXL)
 *  Deprecating all TensorFlow 1 applications. Support will be removed in the next release.
 </details>
 
@@ -205,9 +211,9 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
 <summary>Aug 2022</summary>
 <br>
 
-* Change the folder name of models
-    * NLP : from gpt to gpt2
-    * Speech : from wenet-conformer to conformer
+* Changed the folder name of the following models:
+    * NLP: from `gpt` to `gpt2`
+    * Speech: from `wenet-conformer` to `conformer`
 
 </details>
 <details>
@@ -215,13 +221,13 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
 <br>
 
 *  Major reorganisation of all the apps so that they are arranged as: problem domain / model / framework.
-*  Problem domains: Vision, NLP, Speech, GNN, Sparsity, AI for Simultation, Recomender systems, Reinforcement learning, Probability, Multimodal, and Miscellaneous.
-*  Added those models below to reference models
-    *  Vision : Swin (PyTorch) , ViT (Hugging Face Optimum)
-    *  NLP : GPT2 Small/Medium/Large (PyTorch), BERT-Base/Large (PopXL), BERT-Base(PaddlePaddle), BERT-Base/Large(Hugging Face Optimum), GPT2 Small/Medium (Hugging Face Optimum), RoBERTa Base/Large(Hugging Face Optimum), DeBERTa(Hugging Face Optimum), HuBERT(Hugging Face Optimum), BART(Hugging Face Optimum), T5 small(Hugging Face Optimum)
-    *  Speech : Fastpitch (PyTorch), WeNet-Conformer-Medium(PyTorch) ,Wav2Vec2(Hugging Face Optimum)
-    *  Multimodal : CLIP (PyTorch), LXMERT(Hugging Face Optimum)
-    *  AI for Simulation : et0(TensorFlow 1)
+*  Problem domains: Vision, NLP, Speech, GNN, Sparsity, AI for Simulation, Recommender systems, Reinforcement learning, Probability, Multimodal, and Miscellaneous.
+*  Added the following models:
+    *  Vision: Swin (PyTorch) , ViT (Hugging Face Optimum)
+    *  NLP: GPT2 Small/Medium/Large (PyTorch), BERT-Base/Large (PopXL), BERT-Base (PaddlePaddle), BERT-Base/Large (Hugging Face Optimum), GPT2 Small/Medium (Hugging Face Optimum), RoBERTa Base/Large (Hugging Face Optimum), DeBERTa (Hugging Face Optimum), HuBERT (Hugging Face Optimum), BART (Hugging Face Optimum), T5 small (Hugging Face Optimum)
+    *  Speech: Fastpitch (PyTorch), WeNet-Conformer-Medium (PyTorch) ,Wav2Vec2 (Hugging Face Optimum)
+    *  Multimodal: CLIP (PyTorch), LXMERT (Hugging Face Optimum)
+    *  AI for Simulation: et0 (TensorFlow 1)
 * Removed Conformer-small/large (PyTorch)
 * Archived Minigo (TensorFlow 1)
 
@@ -232,12 +238,12 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
 <summary>May 2022</summary>
 <br>
 
-*  Added those models below to reference models
-    *  Vision : ViT-pretraining(PyTorch), DINO(PyTorch), EfficientDet-inference(TensorFlow 2), Neural Image Fields (TensorFlow 2)
-    *  NLP : PackedBERT(PyTorch, PopART), BERT-Large(TensorFlow 2)
-    *  Speech : FastSpeech2-inference(TensorFlow 2), Conformer-Large(PyTorch)
-    *  GNN : Cluster GCN(TensorFlow 2)
-    *  AI for Simulation : DeepDriveMD(TensorFlow 2)
+*  Added the following models:
+    *  Vision : ViT-pretraining (PyTorch), DINO (PyTorch), EfficientDet-inference (TensorFlow 2), Neural Image Fields (TensorFlow 2)
+    *  NLP : PackedBERT (PyTorch, PopART), BERT-Large (TensorFlow 2)
+    *  Speech : FastSpeech2-inference (TensorFlow 2), Conformer-Large (PyTorch)
+    *  GNN : Cluster GCN (TensorFlow 2)
+    *  AI for Simulation : DeepDriveMD (TensorFlow 2)
 
 </details>
 
@@ -245,11 +251,11 @@ Unless otherwise specified by a LICENSE file in a subdirectory, the LICENSE refe
 <summary>December 2021</summary>
 <br>
 
-*  Added those models below to reference models
-    *  Vision : miniDALL-E(PyTorch), Faster RCNN(PopART), UNet(TensorFlow 2), ResNet50(TensorFlow 2)
-    *  NLP : BERT(TensorFlow 2)
-    *  Speech : FastSpeech2(TensorFlow 2), Transformer Transducer(PopART), Conformer-Small(PyTorch)
-    *  GNN : TGN(TensorFlow 1), MPNN(TensorFlow 2)
+*  Added the following models:
+    *  Vision: miniDALL-E (PyTorch), Faster RCNN (PopART), UNet (TensorFlow 2), ResNet50 (TensorFlow 2)
+    *  NLP: BERT (TensorFlow 2)
+    *  Speech: FastSpeech2 (TensorFlow 2), Transformer Transducer (PopART), Conformer-Small (PyTorch)
+    *  GNN: TGN (TensorFlow 1), MPNN (TensorFlow 2)
 </details>
 
 <br>


### PR DESCRIPTION
Where available, links have been added to the top-level README to run a notebook on Paperspace.

This is a copy of https://github.com/graphcore/examples-internal/pull/701 from examples-internal by @jayniep-gc

Updated examples pre-release due to potential benefits of adding paperspace links to examples README.