### PR TITLE
Adding init to popdist options

### DIFF
--- a/nlp/gpt2/pytorch/ipu_options.py
+++ b/nlp/gpt2/pytorch/ipu_options.py
@@ -48,6 +48,7 @@ def get_options(config):
 
     # PopTorch options
     if config.use_popdist:
+        popdist.init()
         # Use popdist.poptorch options if running in distributed mode
         opts = popdist.poptorch.Options(ipus_per_replica=config.ipus_per_replica)
     else:


### PR DESCRIPTION
Adding a call to popdist.init() in the popdist options setup for GPT2, this enables the use of poprun for GPT2, and hence the use of multiple instances for benchmarking.